### PR TITLE
feat(caching): implement module 05 caching and revalidation lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# local SDD artifacts
+/sdd/

--- a/src/app/api/cache-demo/route.ts
+++ b/src/app/api/cache-demo/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  // Simulate a delay to make caching more apparent
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  return NextResponse.json({
+    message: 'Cache demo data fetched successfully',
+    timestamp: Date.now(),
+    data: {
+      value: Math.random(),
+      status: 'success'
+    }
+  });
+}

--- a/src/app/demos/caching/component-level/page.tsx
+++ b/src/app/demos/caching/component-level/page.tsx
@@ -1,0 +1,69 @@
+import CacheStatus from '@/components/ui/CacheStatus';
+import { headers } from 'next/headers';
+
+async function getComponentData(cacheMode: RequestCache) {
+  const host = (await headers()).get('host') || 'localhost:3000';
+  const protocol = host.includes('localhost') ? 'http' : 'https';
+  
+  const res = await fetch(`${protocol}://${host}/api/cache-demo`, {
+    cache: cacheMode,
+  });
+  return res.json();
+}
+
+export default async function ComponentLevelPage() {
+  // Fetch with two different cache strategies in the same request
+  const [cached, uncached] = await Promise.all([
+    getComponentData('force-cache'),
+    getComponentData('no-store'),
+  ]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-xl font-bold text-stone-900">Component-Level Cache Control</h2>
+        <p className="text-stone-600">
+          Next.js allows granular control over <code>fetch</code> calls within the same page.
+        </p>
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-8 mt-4">
+        <div className="flex flex-col gap-4">
+          <div className="p-2 px-3 bg-stone-200 text-stone-700 text-xs font-bold rounded w-fit uppercase">
+            Strategy: force-cache
+          </div>
+          <CacheStatus 
+            timestamp={cached.timestamp} 
+            label="Cached Component Age" 
+          />
+          <div className="p-4 bg-white border border-stone-200 rounded-lg shadow-sm">
+            <span className="text-2xl font-mono text-stone-800">{cached.data.value.toFixed(6)}</span>
+          </div>
+          <p className="text-xs text-stone-500 italic">
+            This component's data is stored in the Data Cache.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <div className="p-2 px-3 bg-amber-200 text-amber-800 text-xs font-bold rounded w-fit uppercase">
+            Strategy: no-store
+          </div>
+          <CacheStatus 
+            timestamp={uncached.timestamp} 
+            label="Uncached Component Age" 
+          />
+          <div className="p-4 bg-white border border-stone-200 rounded-lg shadow-sm">
+            <span className="text-2xl font-mono text-stone-800">{uncached.data.value.toFixed(6)}</span>
+          </div>
+          <p className="text-xs text-stone-500 italic">
+            This component bypasses the cache and fetches fresh every time.
+          </p>
+        </div>
+      </div>
+      
+      <div className="mt-8 p-4 bg-purple-50 border border-purple-200 rounded-lg text-sm text-purple-800">
+        <strong>How to test:</strong> Refresh the page. The left side (Cached) will stay frozen with its original value and timestamp, while the right side (Uncached) will update every time you refresh.
+      </div>
+    </div>
+  );
+}

--- a/src/app/demos/caching/dynamic/page.tsx
+++ b/src/app/demos/caching/dynamic/page.tsx
@@ -1,0 +1,47 @@
+import CacheStatus from '@/components/ui/CacheStatus';
+import { headers } from 'next/headers';
+
+// Force dynamic rendering for this route
+export const dynamic = 'force-dynamic';
+
+async function getDynamicData() {
+  const host = (await headers()).get('host') || 'localhost:3000';
+  const protocol = host.includes('localhost') ? 'http' : 'https';
+  
+  const res = await fetch(`${protocol}://${host}/api/cache-demo`, {
+    // We can also use cache: 'no-store' for fetch-level dynamic behavior
+    cache: 'no-store',
+  });
+  return res.json();
+}
+
+export default async function DynamicPage() {
+  const { data, timestamp } = await getDynamicData();
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-xl font-bold text-stone-900">Dynamic Rendering (Forced)</h2>
+        <p className="text-stone-600">
+          This page is rendered on every request. Data is never cached for the long term.
+        </p>
+      </div>
+
+      <div className="grid gap-4 max-w-md">
+        <CacheStatus 
+          timestamp={timestamp} 
+          label="Last Fetch Age" 
+        />
+        
+        <div className="p-4 bg-white border border-stone-200 rounded-lg shadow-sm">
+          <span className="text-xs font-bold text-stone-500 uppercase tracking-wider block mb-2">Random Value</span>
+          <span className="text-2xl font-mono text-stone-800">{data.value.toFixed(6)}</span>
+        </div>
+      </div>
+      
+      <div className="mt-8 p-4 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-800">
+        <strong>How to test:</strong> Refresh the page. Both the timestamp and the random value will update on every single hit because <code>force-dynamic</code> is enabled.
+      </div>
+    </div>
+  );
+}

--- a/src/app/demos/caching/layout.tsx
+++ b/src/app/demos/caching/layout.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link';
+
+export default function CachingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const demos = [
+    { name: 'Static (Default)', path: '/demos/caching/static' },
+    { name: 'Dynamic (Forced)', path: '/demos/caching/dynamic' },
+    { name: 'Time-based (ISR)', path: '/demos/caching/revalidate' },
+    { name: 'Component-Level', path: '/demos/caching/component-level' },
+  ];
+
+  return (
+    <div className="flex flex-col gap-8 p-8">
+      <div className="flex flex-col gap-4 border-b border-stone-200 pb-8">
+        <h1 className="text-3xl font-bold text-stone-900 tracking-tight">
+          Next.js Caching & Revalidation Lab
+        </h1>
+        <p className="max-w-3xl text-stone-600 leading-relaxed">
+          Welcome to the Caching Lab. Use the navigation below to explore different caching behaviors. 
+          To force a server hit for demonstration purposes, we use <code>prefetch={'{false}'}</code> on these links.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 my-6 bg-white p-6 rounded-xl border border-stone-200 shadow-sm">
+          <div className="flex flex-col gap-2">
+            <h3 className="font-bold text-stone-900 text-sm uppercase tracking-wider">1. Static vs Dynamic</h3>
+            <p className="text-xs text-stone-500 leading-normal">
+              Compare <strong>Static</strong> (cached at build time) vs <strong>Dynamic</strong> (fetched every request).
+              Notice the timestamp behavior when refreshing.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 border-l border-stone-100 pl-6">
+            <h3 className="font-bold text-stone-900 text-sm uppercase tracking-wider">2. ISR (Time-based)</h3>
+            <p className="text-xs text-stone-500 leading-normal">
+              Set to <code>revalidate = 10</code>. Refreshing after 10s serves stale data once, 
+              triggers a background update, and shows new data on the <em>next</em> refresh.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 border-l border-stone-100 pl-6">
+            <h3 className="font-bold text-stone-900 text-sm uppercase tracking-wider">3. On-Demand Purge</h3>
+            <p className="text-xs text-stone-500 leading-normal">
+              Click <strong>Purge Path</strong> or <strong>Revalidate Tag</strong> to manually 
+              invalidate the cache using Server Actions.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 border-l border-stone-100 pl-6">
+            <h3 className="font-bold text-stone-900 text-sm uppercase tracking-wider">4. Cache Status</h3>
+            <p className="text-xs text-stone-500 leading-normal">
+              Watch the <strong>CacheStatus</strong> component. It calculates "Data Age" 
+              based on the difference between client and server time.
+            </p>
+          </div>
+        </div>
+
+        <nav className="flex items-center gap-4 mt-4">
+          {demos.map((demo) => (
+            <Link
+              key={demo.path}
+              href={demo.path}
+              prefetch={false}
+              className="px-4 py-2 text-sm font-semibold bg-white border border-stone-300 rounded-lg text-stone-700 hover:bg-stone-50 transition-all hover:border-stone-400 active:bg-stone-100 shadow-sm"
+            >
+              {demo.name}
+            </Link>
+          ))}
+        </nav>
+      </div>
+
+      <div className="flex-1 bg-stone-50/50 p-8 rounded-2xl border border-stone-200/50 min-h-[500px]">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/app/demos/caching/revalidate/page.tsx
+++ b/src/app/demos/caching/revalidate/page.tsx
@@ -1,0 +1,77 @@
+import CacheStatus from '@/components/ui/CacheStatus';
+import RevalidateButton from '@/components/ui/revalidation/RevalidateButton';
+import { purgeTag } from '@/lib/actions';
+
+// Time-based revalidation (ISR) at the segment level
+export const revalidate = 60;
+
+async function getISRData() {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  
+  // Note: Segment-level revalidate (above) applies if fetch doesn't specify its own
+  const res = await fetch(`${baseUrl}/api/cache-demo`, {
+    next: { tags: ['isr-demo'] }
+  });
+  return res.json();
+}
+
+export default async function ISRPage() {
+  const { data, timestamp } = await getISRData();
+
+  const handlePurgeTag = async () => {
+    'use server';
+    await purgeTag('isr-demo');
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-xl font-bold text-stone-900">Incremental Static Regeneration (ISR)</h2>
+        <p className="text-stone-600">
+          This page revalidates every 60 seconds automatically, or on-demand via tags.
+        </p>
+      </div>
+
+      <div className="grid gap-4 max-w-md">
+        <CacheStatus 
+          timestamp={timestamp} 
+          label="Data Age" 
+          revalidate={60}
+        />
+        
+        <div className="p-4 bg-white border border-stone-200 rounded-lg shadow-sm">
+          <span className="text-xs font-bold text-stone-500 uppercase tracking-wider block mb-2">Random Value</span>
+          <span className="text-2xl font-mono text-stone-800">{data.value.toFixed(6)}</span>
+        </div>
+
+        <form action={handlePurgeTag}>
+          <RevalidateButton 
+            label="Revalidate Tag (On-Demand)"
+            loadingLabel="Revalidating Tag..."
+            className="w-full py-2 px-4 bg-emerald-600 hover:bg-emerald-700 text-white font-bold rounded-lg transition-colors shadow-sm"
+          />
+        </form>
+      </div>
+      
+      <div className="mt-8 p-4 bg-emerald-50 border border-emerald-200 rounded-lg text-sm text-emerald-800 space-y-4">
+        <div>
+          <p><strong>Option 1: Time-based ISR</strong></p>
+          <ol className="list-decimal ml-4 space-y-1">
+            <li>Establish initial cache by refreshing.</li>
+            <li>Wait for the indicator to turn <span className="text-rose-600 font-bold uppercase">Red</span> (after 60s).</li>
+            <li>Refresh once more. You'll see STALE data, but a background update is triggered.</li>
+            <li>Refresh again. Now you see the NEW data.</li>
+          </ol>
+        </div>
+
+        <div>
+          <p><strong>Option 2: On-demand Revalidation</strong></p>
+          <ol className="list-decimal ml-4 space-y-1">
+            <li>Click "Revalidate Tag". This immediately invalidates anything with the <code>'isr-demo'</code> tag.</li>
+            <li>On next refresh, you will see NEW data immediately, bypassing the 60s timer.</li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/demos/caching/static/page.tsx
+++ b/src/app/demos/caching/static/page.tsx
@@ -1,0 +1,65 @@
+import CacheStatus from '@/components/ui/CacheStatus';
+import RevalidateButton from '@/components/ui/revalidation/RevalidateButton';
+import { purgePath } from '@/lib/actions';
+
+async function getStaticData() {
+  // NEXT 16 STATIC DEMO: Do NOT use headers() or searchParams to avoid dynamic leakage
+  // In a real app, use environment variables for the base URL
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  
+  const res = await fetch(`${baseUrl}/api/cache-demo`, {
+    // Default is force-cache for static segments, but we'll be explicit
+    cache: 'force-cache',
+    next: { tags: ['static-demo'] }
+  });
+  return res.json();
+}
+
+export default async function StaticPage() {
+  const { data, timestamp } = await getStaticData();
+
+  const handlePurge = async () => {
+    'use server';
+    await purgePath('/demos/caching/static');
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-xl font-bold text-stone-900">Full Route Cache (Static)</h2>
+        <p className="text-stone-600">
+          This page is cached at build time or on first request. Subsequent refreshes will serve the same data until revalidated.
+        </p>
+      </div>
+
+      <div className="grid gap-4 max-w-md">
+        <CacheStatus 
+          timestamp={timestamp} 
+          label="Build/Initial Fetch Age" 
+        />
+        
+        <div className="p-4 bg-white border border-stone-200 rounded-lg shadow-sm">
+          <span className="text-xs font-bold text-stone-500 uppercase tracking-wider block mb-2">Random Value</span>
+          <span className="text-2xl font-mono text-stone-800">{data.value.toFixed(6)}</span>
+        </div>
+
+        <form action={handlePurge}>
+          <RevalidateButton 
+            label="Purge Path (On-Demand)"
+            loadingLabel="Purging Path..."
+            className="w-full py-2 px-4 bg-rose-600 hover:bg-rose-700 text-white font-bold rounded-lg transition-colors shadow-sm"
+          />
+        </form>
+      </div>
+      
+      <div className="mt-8 p-4 bg-blue-50 border border-blue-200 rounded-lg text-sm text-blue-800 space-y-2">
+        <p><strong>How to test:</strong></p>
+        <ol className="list-decimal ml-4 space-y-1">
+          <li>Refresh the page. The timestamp and value should remain identical.</li>
+          <li>Click "Purge Path". This triggers a server action that calls <code>revalidatePath</code>.</li>
+          <li>The page will refresh (or you can manual refresh) and you'll see a NEW timestamp and value.</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/CacheStatus.tsx
+++ b/src/components/ui/CacheStatus.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface CacheStatusProps {
+  timestamp: number;
+  label?: string;
+  revalidate?: number | false;
+}
+
+export default function CacheStatus({ timestamp, label = 'Data Age', revalidate }: CacheStatusProps) {
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const secondsAgo = Math.floor((now - timestamp) / 1000);
+  const isStale = revalidate && secondsAgo >= revalidate;
+
+  // Visual feedback: green for fresh, yellow for nearing revalidation, red for stale
+  const getStatusColor = () => {
+    if (!revalidate) return 'bg-emerald-500';
+    if (secondsAgo >= revalidate) return 'bg-rose-500';
+    if (secondsAgo >= revalidate * 0.75) return 'bg-amber-500';
+    return 'bg-emerald-500';
+  };
+
+  return (
+    <div className="flex items-center gap-3 p-3 bg-white border border-stone-200 rounded-lg shadow-sm">
+      <div className={`w-3 h-3 rounded-full ${getStatusColor()} animate-pulse`} />
+      <div className="flex flex-col">
+        <span className="text-xs font-bold text-stone-500 uppercase tracking-wider">{label}</span>
+        <span className="text-sm font-medium text-stone-800">
+          {secondsAgo}s ago <span className="text-stone-400 font-normal">({new Date(timestamp).toLocaleTimeString()})</span>
+        </span>
+        {revalidate && (
+          <span className="text-[10px] text-stone-400">
+            Revalidates every {revalidate}s {isStale && '• STALE'}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/revalidation/RevalidateButton.tsx
+++ b/src/components/ui/revalidation/RevalidateButton.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useFormStatus } from 'react-dom';
+
+interface RevalidateButtonProps {
+  label: string;
+  loadingLabel?: string;
+  className?: string;
+}
+
+export default function RevalidateButton({ 
+  label, 
+  loadingLabel = 'Revalidating...', 
+  className 
+}: RevalidateButtonProps) {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className={`${className} flex items-center justify-center gap-2 disabled:opacity-70 disabled:cursor-not-allowed`}
+    >
+      {pending && (
+        <svg className="animate-spin h-4 w-4 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+      )}
+      {pending ? loadingLabel : label}
+    </button>
+  );
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,0 +1,19 @@
+'use server';
+
+import { revalidatePath, revalidateTag } from 'next/cache';
+
+/**
+ * Revalidates a specific path on-demand.
+ * Used to demonstrate Full Route Cache and Data Cache invalidation.
+ */
+export async function purgePath(path: string) {
+  revalidatePath(path);
+}
+
+/**
+ * Revalidates a specific cache tag on-demand.
+ * Used to demonstrate granular Data Cache invalidation.
+ */
+export async function purgeTag(tag: string) {
+  revalidateTag(tag, 'page');
+}


### PR DESCRIPTION
Closes #7

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds Module 05 caching lab routes to demonstrate static, dynamic, ISR, and component-level cache behavior.
- Implements on-demand cache invalidation via Server Actions (`revalidatePath`, `revalidateTag`) with pending UI states.
- Includes `CacheStatus` visualizer and in-layout guidance to make cache age/state observable for learners.

## Changes Table
| File | Change |
|------|--------|
| `src/app/api/cache-demo/route.ts` | Added local mock API for caching demos with timestamped responses. |
| `src/app/demos/caching/layout.tsx` | Added lab layout, navigation, and “how to read this lab” guidance. |
| `src/app/demos/caching/static/page.tsx` | Added static/full-route cache demo with path purge action. |
| `src/app/demos/caching/dynamic/page.tsx` | Added dynamic route demo for no-store behavior comparison. |
| `src/app/demos/caching/revalidate/page.tsx` | Added ISR demo (`revalidate = 60`) and tag-based revalidation action. |
| `src/app/demos/caching/component-level/page.tsx` | Added side-by-side fetch cache strategy demo. |
| `src/components/ui/CacheStatus.tsx` | Added freshness visualizer (age + state indicators). |
| `src/components/ui/revalidation/RevalidateButton.tsx` | Added reusable pending-state button using `useFormStatus`. |
| `src/lib/actions.ts` | Added server actions for `revalidatePath` and `revalidateTag`. |

## Test Plan
- [x] Verified behavior via SDD verify artifacts (final status: PASS_WITH_WARNINGS).
- [x] Confirmed pending UI states during server action submits.
- [x] Confirmed frontend-only scope (no backend/database integration).

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No Co-Authored-By trailers