### PR TITLE
feat(actions): implement module 06 server actions frontend lab

### DIFF
--- a/src/app/demos/actions/page.tsx
+++ b/src/app/demos/actions/page.tsx
@@ -1,0 +1,63 @@
+import { getTransactions } from '@/lib/data';
+import TransactionForm from '@/components/demos/TransactionForm';
+import OptimisticTransactionList from '@/components/demos/OptimisticTransactionList';
+import { resetDatabase } from '@/lib/actions';
+
+export const metadata = {
+  title: 'Server Actions Lab - Finance Manager',
+  description: 'Practice Next.js Server Actions, useActionState, and useOptimistic.',
+};
+
+export default async function ActionsLabPage() {
+  // Fetch initial data on the server
+  const transactions = await getTransactions();
+
+  return (
+    <div className="container mx-auto max-w-5xl p-6 lg:p-10">
+      <header className="mb-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-grey-900">Server Actions Lab</h1>
+          <p className="text-grey-500">
+            Experiment with mutations, revalidation, and optimistic UI updates.
+          </p>
+        </div>
+        
+        <form action={async () => {
+          'use server';
+          await resetDatabase();
+        }}>
+          <button 
+            type="submit"
+            className="rounded-lg border border-grey-300 px-4 py-2 text-sm font-medium text-grey-900 transition-colors hover:bg-grey-100"
+          >
+            Reset Lab Data
+          </button>
+        </form>
+      </header>
+
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+        {/* Left Column: Form */}
+        <div className="lg:col-span-1">
+          <div className="sticky top-10 space-y-6">
+            <TransactionForm />
+            
+            <div className="rounded-xl bg-grey-100 p-6">
+              <h3 className="mb-2 text-sm font-bold text-grey-900">How it works</h3>
+              <ul className="list-inside list-disc space-y-2 text-xs text-grey-500">
+                <li>Uses <strong>useActionState</strong> for form feedback.</li>
+                <li>Uses <strong>useFormStatus</strong> for the loading button.</li>
+                <li>Uses <strong>revalidatePath</strong> to refresh server data.</li>
+                <li>Simulates persistence with an in-memory <strong>Mock DB</strong>.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        {/* Right Column: List */}
+        <div className="lg:col-span-2">
+          <OptimisticTransactionList initialTransactions={transactions} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/demos/OptimisticTransactionList.tsx
+++ b/src/components/demos/OptimisticTransactionList.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useOptimistic, startTransition } from 'react';
+import { Transaction } from '@/lib/types';
+import { deleteTransaction } from '@/lib/actions';
+import Image from 'next/image';
+
+interface OptimisticTransactionListProps {
+  initialTransactions: Transaction[];
+}
+
+export default function OptimisticTransactionList({
+  initialTransactions,
+}: OptimisticTransactionListProps) {
+  // Expose the optimistic adder via window for verification/integration demo
+  // In a real app, this would be passed via context or props to the form
+  if (typeof window !== 'undefined') {
+    (window as any).addOptimisticTransaction = (transaction: Transaction) => {
+      startTransition(() => {
+        setOptimisticTransactions({ action: 'add', payload: transaction });
+      });
+    };
+  }
+
+  const [optimisticTransactions, setOptimisticTransactions] = useOptimistic(
+    initialTransactions,
+    (state, { action, payload }: { action: 'delete' | 'add'; payload: any }) => {
+      if (action === 'delete') {
+        return state.filter((t) => t.id !== payload);
+      }
+      if (action === 'add') {
+        return [payload, ...state];
+      }
+      return state;
+    }
+  );
+
+  const handleDelete = async (id: string) => {
+    startTransition(() => {
+      setOptimisticTransactions({ action: 'delete', payload: id });
+    });
+    
+    await deleteTransaction(id);
+  };
+
+  return (
+    <div className="rounded-xl bg-white p-6 shadow-sm">
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-xl font-bold text-grey-900">Recent Transactions</h2>
+        <span className="text-xs text-grey-500">
+          Showing {optimisticTransactions.length} items
+        </span>
+      </div>
+
+      <div className="space-y-4">
+        {optimisticTransactions.length === 0 ? (
+          <p className="py-10 text-center text-sm text-grey-500">No transactions found.</p>
+        ) : (
+          optimisticTransactions.map((transaction) => (
+            <div
+              key={transaction.id}
+              className={`flex items-center justify-between border-b border-grey-100 pb-4 last:border-0 last:pb-0 ${
+                (transaction as any).isPending ? 'opacity-50' : ''
+              }`}
+            >
+              <div className="flex items-center gap-4">
+                <div className="relative h-10 w-10 overflow-hidden rounded-full">
+                  <Image
+                    src={transaction.avatar || '/avatars/general.jpg'}
+                    alt={transaction.name}
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+                <div>
+                  <h3 className="text-sm font-bold text-grey-900">{transaction.name}</h3>
+                  <p className="text-xs text-grey-500">{transaction.category}</p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-6">
+                <div className="text-right">
+                  <p className={`text-sm font-bold ${transaction.amount < 0 ? 'text-red-500' : 'text-green-700'}`}>
+                    {transaction.amount < 0 ? '-' : '+'}${Math.abs(transaction.amount).toFixed(2)}
+                  </p>
+                  <p className="text-xs text-grey-500">
+                    {new Date(transaction.date).toLocaleDateString()}
+                  </p>
+                </div>
+                
+                <button
+                  onClick={() => handleDelete(transaction.id)}
+                  className="text-xs font-medium text-red-500 hover:underline"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/demos/TransactionForm.tsx
+++ b/src/components/demos/TransactionForm.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useActionState } from 'react';
+import { useFormStatus } from 'react-dom';
+import { createTransaction, ActionState } from '@/lib/actions';
+
+const initialState: ActionState = {
+  success: false,
+  message: '',
+};
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="w-full rounded-lg bg-grey-900 px-4 py-3 text-sm font-bold text-white transition-colors hover:bg-grey-500 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {pending ? 'Processing...' : 'Add Transaction'}
+    </button>
+  );
+}
+
+export default function TransactionForm() {
+  const [state, formAction] = useActionState(async (prevState: ActionState | null, formData: FormData) => {
+    const name = formData.get('name') as string;
+    const amount = parseFloat(formData.get('amount') as string);
+    const category = formData.get('category') as string;
+
+    // Trigger optimistic update if the adder exists on window
+    if (typeof window !== 'undefined' && (window as any).addOptimisticTransaction && name && !isNaN(amount) && category) {
+      (window as any).addOptimisticTransaction({
+        id: 'temp-' + Date.now(),
+        name,
+        amount,
+        category,
+        date: new Date().toISOString(),
+        avatar: '/avatars/general.jpg',
+        isPending: true // We can use this to style it
+      });
+    }
+
+    return createTransaction(prevState, formData);
+  }, initialState);
+
+  return (
+    <form action={formAction} className="space-y-4 rounded-xl bg-white p-6 shadow-sm">
+      <h2 className="text-xl font-bold text-grey-900">Add New Transaction</h2>
+      
+      {state.message && (
+        <div 
+          className={`rounded-lg p-3 text-sm ${
+            state.success ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+          }`}
+        >
+          {state.message}
+        </div>
+      )}
+
+      <div>
+        <label htmlFor="name" className="mb-1 block text-xs font-bold text-grey-500">
+          Transaction Name
+        </label>
+        <input
+          type="text"
+          id="name"
+          name="name"
+          placeholder="e.g. Monthly Rent"
+          className={`w-full rounded-lg border px-4 py-2 text-sm outline-none focus:border-grey-900 ${
+            state.errors?.name ? 'border-red-500' : 'border-grey-300'
+          }`}
+        />
+        {state.errors?.name && (
+          <p className="mt-1 text-xs text-red-500">{state.errors.name[0]}</p>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="amount" className="mb-1 block text-xs font-bold text-grey-500">
+          Amount
+        </label>
+        <input
+          type="number"
+          id="amount"
+          name="amount"
+          step="0.01"
+          placeholder="e.g. 1500"
+          className={`w-full rounded-lg border px-4 py-2 text-sm outline-none focus:border-grey-900 ${
+            state.errors?.amount ? 'border-red-500' : 'border-grey-300'
+          }`}
+        />
+        {state.errors?.amount && (
+          <p className="mt-1 text-xs text-red-500">{state.errors.amount[0]}</p>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="category" className="mb-1 block text-xs font-bold text-grey-500">
+          Category
+        </label>
+        <select
+          id="category"
+          name="category"
+          className={`w-full rounded-lg border px-4 py-2 text-sm outline-none focus:border-grey-900 ${
+            state.errors?.category ? 'border-red-500' : 'border-grey-300'
+          }`}
+        >
+          <option value="">Select Category</option>
+          <option value="Entertainment">Entertainment</option>
+          <option value="Food">Food</option>
+          <option value="Personal Care">Personal Care</option>
+          <option value="Education">Education</option>
+          <option value="Lifestyle">Lifestyle</option>
+          <option value="Shopping">Shopping</option>
+          <option value="General">General</option>
+        </select>
+        {state.errors?.category && (
+          <p className="mt-1 text-xs text-red-500">{state.errors.category[0]}</p>
+        )}
+      </div>
+
+      <div className="pt-2">
+        <SubmitButton />
+      </div>
+
+      <p className="text-center text-[10px] text-grey-500">
+        Tip: Type "error" in name to simulate a server failure.
+      </p>
+    </form>
+  );
+}

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -4,6 +4,7 @@ export const NAV_ITEMS = [
   { name: 'Budgets', href: '/budgets', icon: 'budgets' },
   { name: 'Pots', href: '/pots', icon: 'pots' },
   { name: 'Recurring Bills', href: '/recurring-bills', icon: 'recurring-bills' },
+  { name: 'Actions Lab', href: '/demos/actions', icon: 'actions' },
 ] as const;
 
 export type NavItem = typeof NAV_ITEMS[number];

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { revalidatePath, revalidateTag } from 'next/cache';
+import { mockDb } from './mock-db';
 
 /**
  * Revalidates a specific path on-demand.
@@ -16,4 +17,109 @@ export async function purgePath(path: string) {
  */
 export async function purgeTag(tag: string) {
   revalidateTag(tag, 'page');
+}
+
+export type ActionState = {
+  success: boolean;
+  message: string;
+  errors?: Record<string, string[]>;
+  data?: any;
+};
+
+/**
+ * Helper to standardise revalidation after an action
+ */
+export async function revalidateAction(path: string = '/demos/actions', tag: string = 'transactions') {
+  revalidatePath(path);
+  revalidateTag(tag, 'page');
+}
+
+/**
+ * Server Action: Create a new transaction
+ */
+export async function createTransaction(prevState: ActionState | null, formData: FormData): Promise<ActionState> {
+  // Simulate network delay
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  const name = formData.get('name') as string;
+  const amountStr = formData.get('amount') as string;
+  const category = formData.get('category') as string;
+
+  const errors: Record<string, string[]> = {};
+
+  if (!name || name.trim().length < 3) {
+    errors.name = ['Name must be at least 3 characters long'];
+  }
+
+  const amount = parseFloat(amountStr);
+  if (isNaN(amount) || amount === 0) {
+    errors.amount = ['Please enter a valid amount'];
+  }
+
+  if (!category) {
+    errors.category = ['Please select a category'];
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return {
+      success: false,
+      message: 'Validation failed',
+      errors,
+    };
+  }
+
+  // Scenario: Simulated Server Error
+  if (name.toLowerCase().includes('error')) {
+    return {
+      success: false,
+      message: 'A simulated server error occurred. Transaction not saved.',
+    };
+  }
+
+  try {
+    mockDb.addTransaction({
+      name,
+      amount,
+      category,
+      avatar: '/avatars/general.jpg',
+    });
+
+    await revalidateAction();
+
+    return {
+      success: true,
+      message: 'Transaction created successfully!',
+    };
+  } catch (e) {
+    return {
+      success: false,
+      message: 'Failed to create transaction',
+    };
+  }
+}
+
+/**
+ * Server Action: Delete a transaction
+ */
+export async function deleteTransaction(id: string): Promise<ActionState> {
+  try {
+    mockDb.deleteTransaction(id);
+    await revalidateAction();
+    return { success: true, message: 'Transaction deleted' };
+  } catch (e) {
+    return { success: false, message: 'Failed to delete transaction' };
+  }
+}
+
+/**
+ * Server Action: Reset the mock database
+ */
+export async function resetDatabase(): Promise<ActionState> {
+  try {
+    mockDb.reset();
+    await revalidateAction();
+    return { success: true, message: 'Database reset' };
+  } catch (e) {
+    return { success: false, message: 'Failed to reset database' };
+  }
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,3 +1,5 @@
+import { mockDb } from './mock-db';
+
 /**
  * Simulates a randomized delay to mimic real-world network latency.
  * @param min Minimum delay in milliseconds
@@ -36,6 +38,7 @@ export interface Pot {
   target: number;
   total: number;
   color: string;
+  theme?: string;
 }
 
 export interface Transaction {
@@ -49,21 +52,12 @@ export interface Transaction {
 
 export const getBalance = async (): Promise<Balance> => {
   await delay();
-  return {
-    current: 4836.00,
-    income: 3814.25,
-    expenses: 1700.50,
-  };
+  return mockDb.getBalance();
 };
 
 export const getBudgets = async (): Promise<Budget[]> => {
   await delay();
-  return [
-    { id: '1', category: 'Entertainment', maximum: 50.00, spent: 15.00, color: '#277C78' },
-    { id: '2', category: 'Bills', maximum: 750.00, spent: 150.00, color: '#82C9D7' },
-    { id: '3', category: 'Dining Out', maximum: 75.00, spent: 40.00, color: '#F2CDAC' },
-    { id: '4', category: 'Personal Care', maximum: 100.00, spent: 25.00, color: '#626070' },
-  ];
+  return mockDb.getBudgets();
 };
 
 export const getUserSettings = async () => {
@@ -79,35 +73,17 @@ export const getBudgetsWithSettings = async (settings: { currency: string; theme
   // Simulate logic dependent on settings
   console.log(`Fetching budgets using currency: ${settings.currency}`);
   await delay();
-  return [
-    { id: '1', category: 'Entertainment', maximum: 50.00, spent: 15.00, color: '#277C78' },
-    { id: '2', category: 'Bills', maximum: 750.00, spent: 150.00, color: '#82C9D7' },
-    { id: '3', category: 'Dining Out', maximum: 75.00, spent: 40.00, color: '#F2CDAC' },
-    { id: '4', category: 'Personal Care', maximum: 100.00, spent: 25.00, color: '#626070' },
-  ];
+  return mockDb.getBudgets();
 };
 
 export const getRecurringBills = async (): Promise<Bill[]> => {
   await delay();
-  return [
-    { id: '1', name: 'Spark Electric', amount: 100.00, dueDate: 'Monthly-02nd', isPaid: true },
-    { id: '2', name: 'Serenity Spa', amount: 25.00, dueDate: 'Monthly-03rd', isPaid: true },
-    { id: '3', name: 'Health-conscious', amount: 15.00, dueDate: 'Monthly-11th', isPaid: false },
-    { id: '4', name: 'Pixel Playground', amount: 10.00, dueDate: 'Monthly-11th', isPaid: false },
-    { id: '5', name: 'Elevate Education', amount: 50.00, dueDate: 'Monthly-15th', isPaid: false },
-    { id: '6', name: 'Archive Antiques', amount: 10.00, dueDate: 'Monthly-26th', isPaid: false },
-    { id: '7', name: 'Swift Savings', amount: 500.00, dueDate: 'Monthly-26th', isPaid: false },
-  ];
+  return mockDb.getBills();
 };
 
 export const getPots = async (): Promise<Pot[]> => {
   await delay();
-  return [
-    { id: '1', name: 'Savings', target: 2000.00, total: 159.00, color: '#277C78' },
-    { id: '2', name: 'Concert Tickets', target: 150.00, total: 110.00, color: '#626070' },
-    { id: '3', name: 'Gift', target: 150.00, total: 40.00, color: '#82C9D7' },
-    { id: '4', name: 'New Laptop', target: 1000.00, total: 10.00, color: '#F2CDAC' },
-  ];
+  return mockDb.getPots();
 };
 
 export const getTransactions = async (
@@ -117,18 +93,7 @@ export const getTransactions = async (
   sort: string = 'Latest'
 ): Promise<Transaction[]> => {
   await delay();
-  const allTransactions: Transaction[] = [
-    { id: '1', name: 'Emma Richardson', category: 'General', date: '2024-08-19', amount: 75.50, avatar: '/avatars/emma-richardson.jpg' },
-    { id: '2', name: 'Savory Bites Bistro', category: 'Dining Out', date: '2024-08-19', amount: -55.50, avatar: '/avatars/savory-bites-bistro.jpg' },
-    { id: '3', name: 'Daniel Carter', category: 'General', date: '2024-08-18', amount: -40.00, avatar: '/avatars/daniel-carter.jpg' },
-    { id: '4', name: 'Sunnyside Aubergine', category: 'Dining Out', date: '2024-08-17', amount: 15.00, avatar: '/avatars/sunnyside-aubergine.jpg' },
-    { id: '5', name: 'Urban Services', category: 'General', date: '2024-08-17', amount: -25.00, avatar: '/avatars/urban-services.jpg' },
-    { id: '6', name: 'Liam Hughes', category: 'Groceries', date: '2024-08-15', amount: 200.00, avatar: '/avatars/liam-hughes.jpg' },
-    { id: '7', name: 'Lily Thompson', category: 'General', date: '2024-08-15', amount: -15.00, avatar: '/avatars/lily-thompson.jpg' },
-    { id: '8', name: 'James Dixon', category: 'Entertainment', date: '2024-08-14', amount: -120.00, avatar: '/avatars/james-dixon.jpg' },
-    { id: '9', name: 'Sebastian Cook', category: 'Transportation', date: '2024-08-14', amount: -35.00, avatar: '/avatars/sebastian-cook.jpg' },
-    { id: '10', name: 'Olivia Miller', category: 'Personal Care', date: '2024-08-13', amount: 50.00, avatar: '/avatars/olivia-miller.jpg' },
-  ];
+  const allTransactions = mockDb.getTransactions();
 
   let filtered = [...allTransactions];
   

--- a/src/lib/mock-db.ts
+++ b/src/lib/mock-db.ts
@@ -1,0 +1,111 @@
+import { Transaction, Budget, Pot, Bill, Balance } from './data';
+
+class MockDatabase {
+  private initialTransactions: Transaction[] = [
+    { id: '1', name: 'Emma Richardson', category: 'General', date: '2024-08-19', amount: 75.50, avatar: '/avatars/emma-richardson.jpg' },
+    { id: '2', name: 'Savory Bites Bistro', category: 'Dining Out', date: '2024-08-19', amount: -55.50, avatar: '/avatars/savory-bites-bistro.jpg' },
+    { id: '3', name: 'Daniel Carter', category: 'General', date: '2024-08-18', amount: -40.00, avatar: '/avatars/daniel-carter.jpg' },
+    { id: '4', name: 'Sunnyside Aubergine', category: 'Dining Out', date: '2024-08-17', amount: 15.00, avatar: '/avatars/sunnyside-aubergine.jpg' },
+    { id: '5', name: 'Urban Services', category: 'General', date: '2024-08-17', amount: -25.00, avatar: '/avatars/urban-services.jpg' },
+    { id: '6', name: 'Liam Hughes', category: 'Groceries', date: '2024-08-15', amount: 200.00, avatar: '/avatars/liam-hughes.jpg' },
+    { id: '7', name: 'Lily Thompson', category: 'General', date: '2024-08-15', amount: -15.00, avatar: '/avatars/lily-thompson.jpg' },
+    { id: '8', name: 'James Dixon', category: 'Entertainment', date: '2024-08-14', amount: -120.00, avatar: '/avatars/james-dixon.jpg' },
+    { id: '9', name: 'Sebastian Cook', category: 'Transportation', date: '2024-08-14', amount: -35.00, avatar: '/avatars/sebastian-cook.jpg' },
+    { id: '10', name: 'Olivia Miller', category: 'Personal Care', date: '2024-08-13', amount: 50.00, avatar: '/avatars/olivia-miller.jpg' },
+  ];
+
+  private initialBalance: Balance = {
+    current: 4836.00,
+    income: 3814.25,
+    expenses: 1700.50,
+  };
+
+  private transactions: Transaction[] = [...this.initialTransactions];
+
+  private budgets: Budget[] = [
+    { id: '1', category: 'Entertainment', maximum: 50.00, spent: 15.00, color: '#277C78' },
+    { id: '2', category: 'Bills', maximum: 750.00, spent: 150.00, color: '#82C9D7' },
+    { id: '3', category: 'Dining Out', maximum: 75.00, spent: 40.00, color: '#F2CDAC' },
+    { id: '4', category: 'Personal Care', maximum: 100.00, spent: 25.00, color: '#626070' },
+  ];
+
+  private pots: Pot[] = [
+    { id: '1', name: 'Savings', target: 2000.00, total: 159.00, color: '#277C78' },
+    { id: '2', name: 'Concert Tickets', target: 150.00, total: 110.00, color: '#626070' },
+    { id: '3', name: 'Gift', target: 150.00, total: 40.00, color: '#82C9D7' },
+    { id: '4', name: 'New Laptop', target: 1000.00, total: 10.00, color: '#F2CDAC' },
+  ];
+
+  private bills: Bill[] = [
+    { id: '1', name: 'Spark Electric', amount: 100.00, dueDate: 'Monthly-02nd', isPaid: true },
+    { id: '2', name: 'Serenity Spa', amount: 25.00, dueDate: 'Monthly-03rd', isPaid: true },
+    { id: '3', name: 'Health-conscious', amount: 15.00, dueDate: 'Monthly-11th', isPaid: false },
+    { id: '4', name: 'Pixel Playground', amount: 10.00, dueDate: 'Monthly-11th', isPaid: false },
+    { id: '5', name: 'Elevate Education', amount: 50.00, dueDate: 'Monthly-15th', isPaid: false },
+    { id: '6', name: 'Archive Antiques', amount: 10.00, dueDate: 'Monthly-26th', isPaid: false },
+    { id: '7', name: 'Swift Savings', amount: 500.00, dueDate: 'Monthly-26th', isPaid: false },
+  ];
+
+  private balance: Balance = { ...this.initialBalance };
+
+  getTransactions() {
+    return [...this.transactions];
+  }
+
+  addTransaction(transaction: Omit<Transaction, 'id' | 'date'>) {
+    const newTransaction: Transaction = {
+      ...transaction,
+      id: Math.random().toString(36).substring(2, 9),
+      date: new Date().toISOString().split('T')[0],
+    };
+    this.transactions.unshift(newTransaction);
+    
+    // Update balance
+    this.balance.current += transaction.amount;
+    if (transaction.amount > 0) {
+      this.balance.income += transaction.amount;
+    } else {
+      this.balance.expenses += Math.abs(transaction.amount);
+    }
+    
+    return newTransaction;
+  }
+
+  deleteTransaction(id: string) {
+    const index = this.transactions.findIndex(t => t.id === id);
+    if (index !== -1) {
+      const t = this.transactions[index];
+      this.balance.current -= t.amount;
+      if (t.amount > 0) {
+        this.balance.income -= t.amount;
+      } else {
+        this.balance.expenses -= Math.abs(t.amount);
+      }
+      this.transactions.splice(index, 1);
+    }
+  }
+
+  getBudgets() {
+    return [...this.budgets];
+  }
+
+  getPots() {
+    return [...this.pots];
+  }
+
+  getBills() {
+    return [...this.bills];
+  }
+
+  getBalance() {
+    return { ...this.balance };
+  }
+
+  reset() {
+    this.transactions = [...this.initialTransactions];
+    this.balance = { ...this.initialBalance };
+  }
+}
+
+// Singleton instance
+export const mockDb = new MockDatabase();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,7 +5,7 @@ export interface Transaction {
   category: string;
   date: string;
   avatar: string;
-  isNew: boolean;
+  isNew?: boolean;
 }
 
 export interface Budget {


### PR DESCRIPTION
## Summary
- add a dedicated Server Actions lab at `/demos/actions` using an in-memory mock database to support frontend-only mutation flows
- implement create/delete/reset server actions with validation, simulated error handling, and cache revalidation hooks
- wire modern React mutation UX patterns (`useActionState`, `useFormStatus`, `useOptimistic`) and expose the lab in sidebar navigation

Closes #9