### PR TITLE
feat(runtime): implement module 07 node vs edge demos

### DIFF
--- a/src/app/api/runtimes/edge/route.ts
+++ b/src/app/api/runtimes/edge/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Next.js Edge Runtime Route Handler Demo
+ * 
+ * BOOTCAMP CONCEPT:
+ * This API route is explicitly configured to run on the Edge Runtime.
+ * Edge routes are lightweight, run on V8 isolates, and have access to Web Standard APIs
+ * but lack some Node.js specific globals (like 'process.versions.node' in production).
+ * 
+ * We use 'export const runtime = "edge"' to force this route into the Edge Runtime.
+ */
+export const runtime = 'edge';
+
+export async function GET() {
+  // Check for the presence of the Next.js Edge Runtime global.
+  // In the Edge runtime, 'EdgeRuntime' is defined as a string (e.g., 'edge-runtime').
+  // This is a safe way to detect the Edge environment without accessing Node-specific 'process.versions'.
+  // @ts-ignore - 'EdgeRuntime' is a global injected by the Next.js Edge runtime environment.
+  const isEdge = typeof EdgeRuntime !== 'undefined';
+  
+  return NextResponse.json({
+    message: 'Hello from the Edge!',
+    runtime: isEdge ? 'Edge (V8 Isolate)' : 'Node.js (Simulated/Local)',
+    timestamp: new Date().toISOString(),
+    // Edge runtime has access to standard Web APIs like Crypto
+    cryptoAvailable: typeof crypto !== 'undefined' && !!crypto.randomUUID,
+    // Demonstrate that we can access the Request/Response context easily
+    env: process.env.NODE_ENV,
+  });
+}

--- a/src/app/demos/runtimes/edge/page.tsx
+++ b/src/app/demos/runtimes/edge/page.tsx
@@ -1,0 +1,91 @@
+/**
+ * Edge Runtime Demo Page
+ * 
+ * This page demonstrates the Next.js Edge Runtime.
+ * Next.js Edge Runtime is a lightweight, performant environment based on V8 Isolates.
+ * 
+ * CONCEPTS:
+ * - Explicit configuration: 'export const runtime = "edge"'.
+ * - Restricted API access: Only Web Standard APIs are available.
+ * - Performance: Faster cold starts and global distribution (when deployed).
+ */
+
+import { RuntimeInfo } from '@/components/demos/runtimes/RuntimeInfo';
+
+// We EXPLICITLY set export const runtime here to 'edge'.
+// This forces Next.js to use the Edge runtime instead of Node.js.
+// IMPORTANT: In the Edge runtime, Node.js modules like 'os' or 'fs' will FAIL.
+export const runtime = 'edge';
+
+export default async function EdgeRuntimePage() {
+  // 1. Web Standard API Demonstration (as required by spec)
+  // We use crypto.subtle to generate a digest as a demo of Web API availability.
+  const encoder = new TextEncoder();
+  const data = encoder.encode('Next.js Edge Runtime');
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+
+  // 2. Demonstration of a Node-only API failure handling
+  // BOOTCAMP CONCEPT: This is how we prove to students that Node APIs are restricted.
+  let osPlatform = 'Unavailable (Edge Runtime)';
+  try {
+    // We check for 'EdgeRuntime' which is a reliable global signal in Next.js Edge.
+    // We avoid 'process.versions' to prevent build-time errors from the Edge checker.
+    // @ts-ignore - 'EdgeRuntime' is defined in the Edge runtime.
+    if (typeof EdgeRuntime !== 'undefined') {
+      osPlatform = 'Restricted: Node.js API not supported';
+    } else {
+      osPlatform = 'Node.js detected (Simulated/Local)';
+    }
+  } catch (e) {
+    osPlatform = 'Error: Node.js API not supported in Edge';
+  }
+  return (
+    <div className="container mx-auto py-10 space-y-8">
+      <div className="space-y-4">
+        <h1 className="text-4xl font-extrabold tracking-tight">Edge Runtime Demo</h1>
+        <p className="text-lg text-muted-foreground max-w-2xl">
+          Exploring the Next.js Edge Runtime. This page runs on a lightweight 
+          V8 Isolate, restricted to standard Web APIs for maximum performance.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
+        {/* Runtime Introspection Component */}
+        <RuntimeInfo />
+
+        {/* Pedagogical Explanation */}
+        <div className="space-y-6">
+          <div className="p-6 border rounded-lg bg-card text-card-foreground shadow-sm">
+            <h2 className="text-xl font-bold mb-4 text-blue-600">Why use Edge?</h2>
+            <ul className="list-disc list-inside space-y-2 text-sm">
+              <li>Low latency and fast cold starts.</li>
+              <li>Global distribution on CDNs (Edge nodes).</li>
+              <li>Perfect for Middleware and dynamic personalization.</li>
+              <li>Minimal footprint and memory overhead.</li>
+            </ul>
+            
+            <div className="mt-6 pt-4 border-t">
+              <p className="text-xs font-semibold text-muted-foreground uppercase mb-2">Web Standard API Demo (SHA-256):</p>
+              <code className="text-[10px] break-all bg-muted p-2 rounded block">
+                {hashHex}
+              </code>
+            </div>
+
+            <div className="mt-4 pt-4 border-t">
+              <p className="text-xs font-semibold text-muted-foreground uppercase">Node API Compatibility:</p>
+              <p className="text-sm font-mono text-red-500 mt-1">{osPlatform}</p>
+            </div>
+          </div>
+
+          <div className="p-4 bg-yellow-50 border-l-4 border-yellow-400 text-yellow-800 text-sm">
+            <strong>Bootcamp Tip:</strong> The Edge runtime has limited API access. 
+            Native Node.js modules like <code className="bg-muted px-1 rounded">os</code>, <code className="bg-muted px-1 rounded">fs</code>, or <code className="bg-muted px-1 rounded">path</code> 
+            will result in a build error or runtime failure if imported here.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/demos/runtimes/node/page.tsx
+++ b/src/app/demos/runtimes/node/page.tsx
@@ -1,0 +1,61 @@
+/**
+ * Node.js Runtime Demo Page
+ * 
+ * This page demonstrates the default Next.js execution environment (Node.js).
+ * Node.js is the standard runtime for Server Components, Route Handlers, and Server Actions.
+ * 
+ * CONCEPTS:
+ * - Default runtime: If not specified, Next.js uses the Node.js runtime.
+ * - Full API access: Access to both Web Standard APIs and Node-specific APIs (os, fs, path).
+ * - Ideal for: Database interactions, complex computations, and using the full npm ecosystem.
+ */
+
+import { RuntimeInfo } from '@/components/demos/runtimes/RuntimeInfo';
+import os from 'os';
+
+// We explicitly NOT set export const runtime here because 'nodejs' is the default.
+// This allows us to use Node.js specific APIs if needed.
+
+export default function NodeRuntimePage() {
+  // Demonstration of a Node-only API access
+  const platform = os.platform();
+  const cpus = os.cpus().length;
+  return (
+    <div className="container mx-auto py-10 space-y-8">
+      <div className="space-y-4">
+        <h1 className="text-4xl font-extrabold tracking-tight">Node.js Runtime Demo</h1>
+        <p className="text-lg text-muted-foreground max-w-2xl">
+          Exploring the standard Next.js execution environment. This page runs on the 
+          full Node.js runtime, allowing access to the entire Node.js ecosystem.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
+        {/* Runtime Introspection Component */}
+        <RuntimeInfo />
+
+        {/* Pedagogical Explanation */}
+        <div className="space-y-6">
+          <div className="p-6 border rounded-lg bg-card text-card-foreground shadow-sm">
+            <h2 className="text-xl font-bold mb-4">Why use Node.js?</h2>
+            <ul className="list-disc list-inside space-y-2 text-sm">
+              <li>Access to <code className="bg-muted px-1 rounded">fs</code>, <code className="bg-muted px-1 rounded">os</code>, and other native modules.</li>
+              <li>Full compatibility with existing Node.js libraries and SDKs.</li>
+              <li>No restriction on the standard Web API set.</li>
+              <li>Standard environment for most Server-Side Rendering (SSR) tasks.</li>
+            </ul>
+            <div className="mt-4 pt-4 border-t">
+              <p className="text-xs font-semibold text-muted-foreground uppercase">Host Info (Node-only):</p>
+              <p className="text-sm font-mono text-green-600 mt-1">Platform: {platform} | CPUs: {cpus}</p>
+            </div>
+          </div>
+
+          <div className="p-4 bg-blue-50 border-l-4 border-blue-400 text-blue-800 text-sm">
+            <strong>Bootcamp Tip:</strong> In the App Router, this is the default behavior.
+            You don't need any special configuration unless you want to switch to the Edge runtime.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/demos/runtimes/protected/page.tsx
+++ b/src/app/demos/runtimes/protected/page.tsx
@@ -1,0 +1,77 @@
+import { headers } from 'next/headers';
+
+/**
+ * Next.js Middleware Interception Demo Page
+ * 
+ * BOOTCAMP CONCEPT:
+ * This page receives custom headers injected by the Next.js Edge Middleware.
+ * Since Middleware runs before the target route, we can 'decorate' the Request object
+ * with additional context, such as user metadata or system markers.
+ * 
+ * We use 'headers()' from 'next/headers' to read these custom markers
+ * and prove the Middleware successfully intercepted the request.
+ */
+export default async function ProtectedDemoPage() {
+  const headerStore = await headers();
+  const injectedHeader = headerStore.get('x-middleware-demo');
+  const runtimeSource = headerStore.get('x-runtime-source');
+
+  return (
+    <div className="container mx-auto py-10 space-y-8">
+      <div className="space-y-4">
+        <h1 className="text-4xl font-extrabold tracking-tight">Middleware Interception</h1>
+        <p className="text-lg text-muted-foreground max-w-2xl">
+          Visualizing the custom headers injected by the Edge-based Middleware 
+          during the request lifecycle.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
+        <div className="p-6 border rounded-lg bg-card text-card-foreground shadow-sm">
+          <h2 className="text-xl font-bold mb-4 text-purple-600">Middleware Context</h2>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <span className="font-semibold text-muted-foreground">Header Injected:</span>
+              <span className={`font-mono ${injectedHeader === 'active' ? 'text-green-600' : 'text-red-600'}`}>
+                {injectedHeader || 'No'}
+              </span>
+              
+              <span className="font-semibold text-muted-foreground">Source Runtime:</span>
+              <span className="font-mono text-blue-600">
+                {runtimeSource || 'Unknown'}
+              </span>
+            </div>
+
+            <div className="p-4 bg-muted rounded border text-xs overflow-auto">
+              <p className="font-bold mb-1">Raw Headers (Injected):</p>
+              <pre>
+                {JSON.stringify({
+                  'x-middleware-demo': injectedHeader,
+                  'x-runtime-source': runtimeSource,
+                }, null, 2)}
+              </pre>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <div className="p-6 border rounded-lg bg-card text-card-foreground shadow-sm">
+            <h2 className="text-xl font-bold mb-4">How it works?</h2>
+            <ol className="list-decimal list-inside space-y-3 text-sm">
+              <li>Request hits <code className="bg-muted px-1 rounded">/demos/runtimes/protected</code>.</li>
+              <li>Next.js identifies the <code className="bg-muted px-1 rounded">middleware.ts</code> matcher.</li>
+              <li>Middleware runs in the <strong>Edge Runtime</strong>.</li>
+              <li>Custom headers are appended to the request.</li>
+              <li>Next.js renders this Server Component and retrieves the headers.</li>
+            </ol>
+          </div>
+
+          <div className="p-4 bg-purple-50 border-l-4 border-purple-400 text-purple-800 text-sm italic">
+            <strong>Bootcamp Insight:</strong> Use Middleware sparingly. 
+            Keep it fast and focused, as it adds latency to every matched request.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/demos/runtimes/RuntimeInfo.tsx
+++ b/src/components/demos/runtimes/RuntimeInfo.tsx
@@ -1,0 +1,75 @@
+/**
+ * RuntimeInfo Component
+ * 
+ * Displays details about the current Next.js runtime (Node.js vs Edge).
+ * This component is designed for pedagogical purposes to help students visualize
+ * the differences in the execution environment of their routes.
+ * 
+ * CONCEPTS:
+ * - Runtime configuration: Next.js routes can explicitly set 'runtime = "edge"'.
+ * - API Constraints: Certain APIs are only available in specific runtimes.
+ * - This component should be used in both Server and Client environments (if hydrated correctly).
+ */
+
+import { getRuntimeInfo } from '@/lib/runtimes/detector';
+
+export function RuntimeInfo() {
+  const info = getRuntimeInfo();
+
+  return (
+    <div className="p-6 border rounded-lg bg-card text-card-foreground shadow-sm">
+      <h2 className="text-xl font-bold mb-4">Current Runtime Details</h2>
+      
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-muted-foreground">Runtime Name</p>
+          <p className={`text-lg font-bold ${info.type === 'edge' ? 'text-blue-500' : 'text-green-500'}`}>
+            {info.name}
+          </p>
+        </div>
+        
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-muted-foreground">Identifier</p>
+          <code className="text-xs bg-muted px-1 py-0.5 rounded">{info.type}</code>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <h3 className="text-sm font-semibold mb-2">Available APIs (Introspection)</h3>
+        <ul className="space-y-2 text-sm">
+          <li className="flex justify-between items-center border-b pb-1">
+            <span>process</span>
+            <span className={info.apis.hasProcess ? 'text-green-600' : 'text-red-600'}>
+              {info.apis.hasProcess ? '✅ Available' : '❌ Missing'}
+            </span>
+          </li>
+          <li className="flex justify-between items-center border-b pb-1">
+            <span>Buffer</span>
+            <span className={info.apis.hasBuffer ? 'text-green-600' : 'text-red-600'}>
+              {info.apis.hasBuffer ? '✅ Available' : '❌ Missing'}
+            </span>
+          </li>
+          <li className="flex justify-between items-center border-b pb-1">
+            <span>Web Crypto (globalThis.crypto)</span>
+            <span className={info.apis.hasCrypto ? 'text-green-600' : 'text-red-600'}>
+              {info.apis.hasCrypto ? '✅ Available' : '❌ Missing'}
+            </span>
+          </li>
+          <li className="flex justify-between items-center">
+            <span>Native Node Modules (e.g. 'os')</span>
+            <span className={info.apis.hasOs ? 'text-green-600' : 'text-red-600'}>
+              {info.apis.hasOs ? '✅ Available' : '❌ Restricted'}
+            </span>
+          </li>
+        </ul>
+      </div>
+
+      <div className="mt-6 p-3 bg-muted/50 rounded text-xs text-muted-foreground italic">
+        {info.type === 'edge' 
+          ? "💡 NOTE: The Edge runtime uses V8 Isolate and only supports Web Standard APIs. It is lightweight and highly performant for middleware and specific routes."
+          : "💡 NOTE: The Node.js runtime is the standard execution environment. It has access to the full Node.js API ecosystem and ecosystem libraries."
+        }
+      </div>
+    </div>
+  );
+}

--- a/src/lib/runtimes/detector.ts
+++ b/src/lib/runtimes/detector.ts
@@ -1,0 +1,31 @@
+/**
+ * Runtime Detector Utility
+ * 
+ * Provides information about the current execution environment in Next.js.
+ * This is used to demonstrate the differences between Node.js and Edge runtimes.
+ * 
+ * CONCEPTS:
+ * - Next.js can execute code in two different runtimes: Node.js (standard) and Edge (V8 Isolate).
+ * - Certain APIs (like 'os' or 'fs') are only available in Node.js.
+ * - Web Standard APIs (like 'crypto') are available in both.
+ */
+
+export const getRuntimeInfo = () => {
+  // We check for 'EdgeRuntime' which is a reliable global signal in Next.js Edge.
+  // We avoid 'process.versions' to prevent build-time errors from the Edge checker.
+  // @ts-ignore - 'EdgeRuntime' is defined in the Edge runtime.
+  const isEdge = typeof EdgeRuntime !== 'undefined';
+  
+  return {
+    name: isEdge ? 'Edge' : 'Node.js',
+    type: isEdge ? 'edge' : 'nodejs',
+    // Example of API availability checks
+    apis: {
+      hasProcess: typeof process !== 'undefined',
+      hasBuffer: typeof Buffer !== 'undefined',
+      hasCrypto: typeof crypto !== 'undefined',
+      hasOs: !isEdge, // Simplification for demo
+    },
+    env: process.env.NODE_ENV || 'development',
+  };
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+/**
+ * Next.js Middleware Demo
+ * 
+ * BOOTCAMP CONCEPT:
+ * Middleware in Next.js runs in the Edge Runtime. This means it must only use
+ * Web Standard APIs and has extremely low latency since it runs on V8 isolates.
+ * 
+ * Middleware is the perfect place to:
+ * 1. Inspect and modify Request headers.
+ * 2. Handle simple authentication or redirection.
+ * 3. Log traffic metrics.
+ * 
+ * In this demo, we use a 'matcher' to limit its execution to specific routes,
+ * ensuring it doesn't slow down the rest of our application.
+ */
+
+export function middleware(request: NextRequest) {
+  // 1. Log that the middleware was triggered
+  console.log(`[Middleware] Intercepted request to: ${request.nextUrl.pathname}`);
+
+  // 2. Clone the request headers and add our custom 'demo' header per spec
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-middleware-demo', 'active');
+  requestHeaders.set('x-runtime-source', 'Next.js Edge Middleware');
+
+  // 3. Pass the modified headers to the underlying route
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+}
+
+/**
+ * Configure which routes this middleware should run on.
+ * 
+ * BOOTCAMP CONCEPT:
+ * Scoping middleware with a matcher is CRITICAL for performance.
+ * We only want to run this demo logic on the protected demo route.
+ */
+export const config = {
+  matcher: '/demos/runtimes/protected/:path*',
+};


### PR DESCRIPTION
## Summary
- add runtime demonstration routes to compare Node.js default runtime and Edge runtime behavior in Next.js App Router
- add an Edge route handler and scoped middleware-protected demo to visualize runtime constraints and header interception
- include shared runtime detection/visualization utilities to keep the bootcamp demos explicit and reusable

Closes #11