### PR TITLE
fix(app): resolve walkthrough audit blockers

### DIFF
--- a/src/app/api/cache-demo/route.ts
+++ b/src/app/api/cache-demo/route.ts
@@ -1,15 +1,7 @@
 import { NextResponse } from 'next/server';
+import { getCacheDemoData } from '@/data/cache-demo';
 
 export async function GET() {
-  // Simulate a delay to make caching more apparent
-  await new Promise((resolve) => setTimeout(resolve, 500));
-
-  return NextResponse.json({
-    message: 'Cache demo data fetched successfully',
-    timestamp: Date.now(),
-    data: {
-      value: Math.random(),
-      status: 'success'
-    }
-  });
+  const data = await getCacheDemoData();
+  return NextResponse.json(data);
 }

--- a/src/app/demos/actions/page.tsx
+++ b/src/app/demos/actions/page.tsx
@@ -10,7 +10,7 @@ export const metadata = {
 
 export default async function ActionsLabPage() {
   // Fetch initial data on the server
-  const transactions = await getTransactions();
+  const { transactions } = await getTransactions();
 
   return (
     <div className="container mx-auto max-w-5xl p-6 lg:p-10">

--- a/src/app/demos/caching/revalidate/page.tsx
+++ b/src/app/demos/caching/revalidate/page.tsx
@@ -1,19 +1,19 @@
 import CacheStatus from '@/components/ui/CacheStatus';
 import RevalidateButton from '@/components/ui/revalidation/RevalidateButton';
 import { purgeTag } from '@/lib/actions';
+import { getCacheDemoData } from '@/data/cache-demo';
+import { unstable_cache } from 'next/cache';
 
 // Time-based revalidation (ISR) at the segment level
 export const revalidate = 60;
 
-async function getISRData() {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-  
-  // Note: Segment-level revalidate (above) applies if fetch doesn't specify its own
-  const res = await fetch(`${baseUrl}/api/cache-demo`, {
-    next: { tags: ['isr-demo'] }
-  });
-  return res.json();
-}
+// Using unstable_cache to keep the teaching intent of shared data cache
+// while avoiding network self-fetch during prerender.
+const getISRData = unstable_cache(
+  async () => getCacheDemoData(),
+  ['isr-demo-data'],
+  { tags: ['isr-demo'] }
+);
 
 export default async function ISRPage() {
   const { data, timestamp } = await getISRData();

--- a/src/app/demos/caching/static/page.tsx
+++ b/src/app/demos/caching/static/page.tsx
@@ -1,19 +1,16 @@
 import CacheStatus from '@/components/ui/CacheStatus';
 import RevalidateButton from '@/components/ui/revalidation/RevalidateButton';
 import { purgePath } from '@/lib/actions';
+import { getCacheDemoData } from '@/data/cache-demo';
+import { unstable_cache } from 'next/cache';
 
-async function getStaticData() {
-  // NEXT 16 STATIC DEMO: Do NOT use headers() or searchParams to avoid dynamic leakage
-  // In a real app, use environment variables for the base URL
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-  
-  const res = await fetch(`${baseUrl}/api/cache-demo`, {
-    // Default is force-cache for static segments, but we'll be explicit
-    cache: 'force-cache',
-    next: { tags: ['static-demo'] }
-  });
-  return res.json();
-}
+// Using unstable_cache to keep the teaching intent of shared data cache
+// while avoiding network self-fetch during prerender.
+const getStaticData = unstable_cache(
+  async () => getCacheDemoData(),
+  ['static-demo-data'],
+  { tags: ['static-demo'] }
+);
 
 export default async function StaticPage() {
   const { data, timestamp } = await getStaticData();

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -19,12 +19,12 @@ export default async function TransactionsPage({
   const query = searchParams?.query || "";
   const page = parseInt(searchParams?.page || "1");
 
-  const initialTransactions = await getTransactions(query, page);
+  const data = await getTransactions(query, page);
 
   return (
     <div className="space-y-6">
       <PageHeader title="Transactions" />
-      <TransactionsContainer initialData={initialTransactions} />
+      <TransactionsContainer initialData={data} />
     </div>
   );
 }

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,9 +1,15 @@
 import { cn } from '@/lib/utils';
 
-export function PageHeader({ title, className }: { title: string, className?: string }) {
+interface PageHeaderProps {
+  title: string;
+  className?: string;
+  as?: 'h1' | 'h2' | 'h3';
+}
+
+export function PageHeader({ title, className, as: Tag = 'h1' }: PageHeaderProps) {
   return (
     <header className={cn("mb-8", className)}>
-      <h2 className="text-3xl font-bold text-grey-900 tracking-tight">{title}</h2>
+      <Tag className="text-3xl font-bold text-grey-900 tracking-tight">{title}</Tag>
     </header>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,6 +32,7 @@ export function Sidebar({ className }: { className?: string }) {
               key={item.href}
               href={item.href}
               title={isCollapsed ? item.name : undefined}
+              aria-current={isActive ? "page" : undefined}
               className={cn(
                 "flex flex-col items-center space-y-1 px-4 py-2 transition-colors lg:flex-row lg:space-x-3 lg:space-y-0 lg:rounded-lg lg:py-3",
                 isActive 

--- a/src/components/demos/OptimisticTransactionList.tsx
+++ b/src/components/demos/OptimisticTransactionList.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useOptimistic, startTransition } from 'react';
+import { useOptimistic, startTransition, useEffect } from 'react';
 import { Transaction } from '@/lib/types';
 import { deleteTransaction } from '@/lib/actions';
-import Image from 'next/image';
+import Avatar from '@/components/ui/Avatar';
 
 interface OptimisticTransactionListProps {
   initialTransactions: Transaction[];
@@ -12,16 +12,6 @@ interface OptimisticTransactionListProps {
 export default function OptimisticTransactionList({
   initialTransactions,
 }: OptimisticTransactionListProps) {
-  // Expose the optimistic adder via window for verification/integration demo
-  // In a real app, this would be passed via context or props to the form
-  if (typeof window !== 'undefined') {
-    (window as any).addOptimisticTransaction = (transaction: Transaction) => {
-      startTransition(() => {
-        setOptimisticTransactions({ action: 'add', payload: transaction });
-      });
-    };
-  }
-
   const [optimisticTransactions, setOptimisticTransactions] = useOptimistic(
     initialTransactions,
     (state, { action, payload }: { action: 'delete' | 'add'; payload: any }) => {
@@ -34,6 +24,20 @@ export default function OptimisticTransactionList({
       return state;
     }
   );
+
+  // Expose the optimistic adder via window for verification/integration demo
+  // In a real app, this would be passed via context or props to the form.
+  // Move to useEffect to avoid side effects in render.
+  useEffect(() => {
+    (window as any).addOptimisticTransaction = (transaction: Transaction) => {
+      startTransition(() => {
+        setOptimisticTransactions({ action: 'add', payload: transaction });
+      });
+    };
+    return () => {
+      delete (window as any).addOptimisticTransaction;
+    };
+  }, [setOptimisticTransactions]);
 
   const handleDelete = async (id: string) => {
     startTransition(() => {
@@ -64,14 +68,14 @@ export default function OptimisticTransactionList({
               }`}
             >
               <div className="flex items-center gap-4">
-                <div className="relative h-10 w-10 overflow-hidden rounded-full">
-                  <Image
-                    src={transaction.avatar || '/avatars/general.jpg'}
-                    alt={transaction.name}
-                    fill
-                    className="object-cover"
-                  />
-                </div>
+                <Avatar 
+                  src={transaction.avatar} 
+                  alt={transaction.name}
+                  width={40}
+                  height={40}
+                  className="h-10 w-10"
+                  fallbackText={transaction.name.charAt(0)}
+                />
                 <div>
                   <h3 className="text-sm font-bold text-grey-900">{transaction.name}</h3>
                   <p className="text-xs text-grey-500">{transaction.category}</p>

--- a/src/components/overview/OverviewTransactions.tsx
+++ b/src/components/overview/OverviewTransactions.tsx
@@ -1,9 +1,9 @@
 import { getTransactions } from "@/lib/data";
 import Link from "next/link";
-import Image from "next/image";
+import Avatar from "@/components/ui/Avatar";
 
 export async function OverviewTransactions() {
-  const transactions = await getTransactions();
+  const { transactions } = await getTransactions();
 
   return (
     <div className="bg-white p-6 rounded-xl shadow-sm border border-slate-200">
@@ -15,22 +15,14 @@ export async function OverviewTransactions() {
         {transactions.map((transaction) => (
           <div key={transaction.id} className="flex items-center justify-between py-4 border-b border-slate-100 last:border-0">
             <div className="flex items-center gap-4">
-              <div className="h-10 w-10 rounded-full bg-slate-100 overflow-hidden flex-shrink-0 relative">
-                {transaction.avatar ? (
-                  <Image 
-                    src={transaction.avatar} 
-                    alt={transaction.name}
-                    width={40}
-                    height={40}
-                    className="object-cover"
-                    loading="lazy"
-                  />
-                ) : (
-                  <div className="h-full w-full flex items-center justify-center bg-slate-200 text-slate-500 text-xs uppercase">
-                    {transaction.name.charAt(0)}
-                  </div>
-                )}
-              </div>
+              <Avatar 
+                src={transaction.avatar} 
+                alt={transaction.name}
+                width={40}
+                height={40}
+                className="h-10 w-10"
+                fallbackText={transaction.name.charAt(0)}
+              />
               <div>
                 <p className="font-bold text-slate-900">{transaction.name}</p>
                 <p className="text-sm text-slate-500">{transaction.category}</p>

--- a/src/components/overview/RecentTransactions.tsx
+++ b/src/components/overview/RecentTransactions.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Image from "next/image";
 
 export async function RecentTransactions() {
-  const transactions = await getTransactions();
+  const { transactions } = await getTransactions();
 
   return (
     <div className="bg-white p-6 rounded-xl shadow-sm border border-slate-200">

--- a/src/components/transactions/TransactionsContainer.tsx
+++ b/src/components/transactions/TransactionsContainer.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { Transaction } from "@/lib/data";
+import { Transaction, TransactionResponse } from "@/lib/data";
 import useSWR from "swr";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
-import Image from "next/image";
+import Avatar from "@/components/ui/Avatar";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 interface TransactionsContainerProps {
-  initialData: Transaction[];
+  initialData: TransactionResponse;
 }
 
 // [CONCEPT: State Management at Client Boundary]
@@ -24,7 +24,7 @@ export function TransactionsContainer({ initialData }: TransactionsContainerProp
   const sort = searchParams.get('sort') || 'Latest';
   const page = searchParams.get('page') || '1';
   
-  const { data, error, isLoading } = useSWR<Transaction[]>(
+  const { data, error, isLoading } = useSWR<TransactionResponse>(
     `/api/transactions?query=${query}&category=${category}&sort=${sort}&page=${page}`,
     fetcher,
     { fallbackData: initialData }
@@ -50,14 +50,17 @@ export function TransactionsContainer({ initialData }: TransactionsContainerProp
     return () => clearTimeout(timer);
   }, [searchTerm, query]);
 
-  const transactions = data || initialData;
+  const transactions = data?.transactions || initialData.transactions;
+  const hasMore = data?.hasMore ?? initialData.hasMore;
 
   return (
     <div className="space-y-6">
       <div className="bg-white p-6 rounded-xl shadow-sm border border-slate-200">
         <div className="flex flex-col md:flex-row gap-4 justify-between mb-8">
           <div className="relative w-full md:w-64">
+            <label htmlFor="transaction-search" className="sr-only">Search transactions</label>
             <input
+              id="transaction-search"
               type="text"
               placeholder="Search transactions"
               className="w-full pl-4 pr-10 py-2 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-slate-900"
@@ -72,33 +75,44 @@ export function TransactionsContainer({ initialData }: TransactionsContainerProp
           </div>
           
           <div className="flex gap-4">
-            <select 
-              value={sort}
-              onChange={(e) => handleParamChange('sort', e.target.value)}
-              className="px-4 py-2 border border-slate-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-slate-900"
-            >
-              <option value="Latest">Latest</option>
-              <option value="Oldest">Oldest</option>
-              <option value="Highest">Highest</option>
-              <option value="Lowest">Lowest</option>
-            </select>
-            <select 
-              value={category}
-              onChange={(e) => handleParamChange('category', e.target.value)}
-              className="px-4 py-2 border border-slate-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-slate-900"
-            >
-              <option value="All Categories">All Categories</option>
-              <option value="Entertainment">Entertainment</option>
-              <option value="Bills">Bills</option>
-              <option value="Groceries">Groceries</option>
-              <option value="Dining Out">Dining Out</option>
-              <option value="Transportation">Transportation</option>
-              <option value="Personal Care">Personal Care</option>
-              <option value="Education">Education</option>
-              <option value="Lifestyle">Lifestyle</option>
-              <option value="Shopping">Shopping</option>
-              <option value="General">General</option>
-            </select>
+            <div className="flex items-center gap-2">
+              <label htmlFor="sort-select" className="hidden lg:block text-slate-500 text-sm">Sort by</label>
+              <select 
+                id="sort-select"
+                aria-label="Sort transactions by"
+                value={sort}
+                onChange={(e) => handleParamChange('sort', e.target.value)}
+                className="px-4 py-2 border border-slate-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-slate-900"
+              >
+                <option value="Latest">Latest</option>
+                <option value="Oldest">Oldest</option>
+                <option value="Highest">Highest</option>
+                <option value="Lowest">Lowest</option>
+              </select>
+            </div>
+            
+            <div className="flex items-center gap-2">
+              <label htmlFor="category-select" className="hidden lg:block text-slate-500 text-sm">Category</label>
+              <select 
+                id="category-select"
+                aria-label="Filter transactions by category"
+                value={category}
+                onChange={(e) => handleParamChange('category', e.target.value)}
+                className="px-4 py-2 border border-slate-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-slate-900"
+              >
+                <option value="All Categories">All Categories</option>
+                <option value="Entertainment">Entertainment</option>
+                <option value="Bills">Bills</option>
+                <option value="Groceries">Groceries</option>
+                <option value="Dining Out">Dining Out</option>
+                <option value="Transportation">Transportation</option>
+                <option value="Personal Care">Personal Care</option>
+                <option value="Education">Education</option>
+                <option value="Lifestyle">Lifestyle</option>
+                <option value="Shopping">Shopping</option>
+                <option value="General">General</option>
+              </select>
+            </div>
           </div>
         </div>
 
@@ -106,10 +120,10 @@ export function TransactionsContainer({ initialData }: TransactionsContainerProp
           <table className="w-full text-left">
             <thead>
               <tr className="border-b border-slate-100 text-slate-500 text-sm">
-                <th className="pb-4 font-normal">Recipient / Sender</th>
-                <th className="pb-4 font-normal">Category</th>
-                <th className="pb-4 font-normal">Transaction Date</th>
-                <th className="pb-4 font-normal text-right">Amount</th>
+                <th scope="col" className="pb-4 font-normal">Recipient / Sender</th>
+                <th scope="col" className="pb-4 font-normal">Category</th>
+                <th scope="col" className="pb-4 font-normal">Transaction Date</th>
+                <th scope="col" className="pb-4 font-normal text-right">Amount</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-50">
@@ -126,20 +140,14 @@ export function TransactionsContainer({ initialData }: TransactionsContainerProp
                   <tr key={t.id} className="text-sm">
                     <td className="py-4">
                       <div className="flex items-center gap-3">
-                        <div className="h-8 w-8 rounded-full bg-slate-100 flex items-center justify-center text-slate-500 text-xs font-bold overflow-hidden relative">
-                          {t.avatar ? (
-                            <Image 
-                              src={t.avatar} 
-                              alt={t.name}
-                              width={32}
-                              height={32}
-                              className="object-cover"
-                              loading="lazy"
-                            />
-                          ) : (
-                            t.name.charAt(0)
-                          )}
-                        </div>
+                        <Avatar 
+                          src={t.avatar} 
+                          alt={t.name}
+                          width={32}
+                          height={32}
+                          className="h-8 w-8"
+                          fallbackText={t.name.charAt(0)}
+                        />
                         <span className="font-bold text-slate-900">{t.name}</span>
                       </div>
                     </td>
@@ -159,6 +167,7 @@ export function TransactionsContainer({ initialData }: TransactionsContainerProp
           <div className="flex gap-2">
             <button 
               className="px-4 py-2 border border-slate-200 rounded-lg hover:bg-slate-50 disabled:opacity-50"
+              aria-label="Previous page"
               disabled={parseInt(page) <= 1}
               onClick={() => {
                 const params = new URLSearchParams(searchParams.toString());
@@ -170,7 +179,8 @@ export function TransactionsContainer({ initialData }: TransactionsContainerProp
             </button>
             <button 
               className="px-4 py-2 border border-slate-200 rounded-lg hover:bg-slate-50 disabled:opacity-50"
-              disabled={transactions.length < 10}
+              aria-label="Next page"
+              disabled={!hasMore}
               onClick={() => {
                 const params = new URLSearchParams(searchParams.toString());
                 params.set('page', (parseInt(page) + 1).toString());

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState } from 'react';
+import Image, { ImageProps } from 'next/image';
+import { cn } from '@/lib/utils';
+
+interface AvatarProps extends Omit<ImageProps, 'src' | 'onError'> {
+  src?: string | null;
+  fallbackText?: string;
+}
+
+export default function Avatar({ 
+  src, 
+  alt = 'avatar', 
+  className, 
+  fallbackText = '?', 
+  ...props 
+}: AvatarProps) {
+  const [error, setError] = useState(false);
+
+  const containerClasses = cn(
+    "relative flex shrink-0 overflow-hidden rounded-full bg-stone-100 items-center justify-center",
+    className
+  );
+
+  if (!src || error) {
+    return (
+      <div className={containerClasses}>
+        <span className="text-xs font-bold text-stone-500 uppercase">
+          {fallbackText.substring(0, 2)}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={containerClasses}>
+      <Image
+        src={src}
+        alt={alt}
+        onError={() => setError(true)}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/CacheStatus.tsx
+++ b/src/components/ui/CacheStatus.tsx
@@ -10,16 +10,21 @@ interface CacheStatusProps {
 }
 
 export default function CacheStatus({ timestamp, label = 'Data Age', revalidate }: CacheStatusProps) {
-  const [now, setNow] = useState(Date.now());
+  // Use timestamp as initial value to ensure hydration match
+  const [now, setNow] = useState(timestamp);
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    setMounted(true);
+    setNow(Date.now());
     const interval = setInterval(() => {
       setNow(Date.now());
     }, 1000);
     return () => clearInterval(interval);
   }, []);
 
-  const secondsAgo = Math.floor((now - timestamp) / 1000);
+  const effectiveNow = mounted ? now : timestamp;
+  const secondsAgo = Math.floor((effectiveNow - timestamp) / 1000);
   const isStale = revalidate && secondsAgo >= revalidate;
 
   // Visual feedback: green for fresh, yellow for nearing revalidation, red for stale

--- a/src/data/cache-demo.ts
+++ b/src/data/cache-demo.ts
@@ -1,0 +1,22 @@
+export interface CacheDemoData {
+  message: string;
+  timestamp: number;
+  data: {
+    value: number;
+    status: string;
+  };
+}
+
+export async function getCacheDemoData(): Promise<CacheDemoData> {
+  // Simulate a delay to make caching more apparent
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  return {
+    message: 'Cache demo data fetched successfully',
+    timestamp: Date.now(),
+    data: {
+      value: Math.random(),
+      status: 'success'
+    }
+  };
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -50,6 +50,12 @@ export interface Transaction {
   avatar: string;
 }
 
+export interface TransactionResponse {
+  transactions: Transaction[];
+  totalCount: number;
+  hasMore: boolean;
+}
+
 export const getBalance = async (): Promise<Balance> => {
   await delay();
   return mockDb.getBalance();
@@ -91,7 +97,7 @@ export const getTransactions = async (
   page: number = 1,
   category: string = 'All Categories',
   sort: string = 'Latest'
-): Promise<Transaction[]> => {
+): Promise<TransactionResponse> => {
   await delay();
   const allTransactions = mockDb.getTransactions();
 
@@ -127,17 +133,25 @@ export const getTransactions = async (
 
   const pageSize = 10;
   const start = (page - 1) * pageSize;
-  return filtered.slice(start, start + pageSize);
+  const transactions = filtered.slice(start, start + pageSize);
+  const totalCount = filtered.length;
+  const hasMore = start + pageSize < totalCount;
+
+  return {
+    transactions,
+    totalCount,
+    hasMore
+  };
 };
 
 // Compatibility export for origin/main calls
 export const getBills = getRecurringBills;
 export const getOverviewData = async () => {
-  const [balance, transactions, budgets, pots] = await Promise.all([
+  const [balance, transData, budgets, pots] = await Promise.all([
     getBalance(),
     getTransactions(),
     getBudgets(),
     getPots()
   ]);
-  return { balance, transactions, budgets, pots };
+  return { balance, transactions: transData.transactions, budgets, pots };
 };


### PR DESCRIPTION
Closes #21

## Summary
- remove fetch-to-self pattern in caching demo Server Components by using shared server-side data access
- add a resilient avatar fallback component and integrate it in overview/transactions/demo lists
- fix hydration/purity/accessibility/semantics issues and improve transactions pagination metadata handling

## Changes
| File | Change |
|------|--------|
| `src/data/cache-demo.ts` | Add shared cache demo data generator |
| `src/app/api/cache-demo/route.ts` | Reuse shared data source |
| `src/app/demos/caching/static/page.tsx` | Remove self-fetch and use server-side cached data |
| `src/app/demos/caching/revalidate/page.tsx` | Remove self-fetch and use server-side cached data |
| `src/components/ui/Avatar.tsx` | Add image fallback avatar component |
| `src/components/ui/CacheStatus.tsx` | Apply hydration-safe state pattern |
| `src/components/transactions/TransactionsContainer.tsx` | Add accessibility labels and pagination robustness |
| `src/lib/data.ts` | Add transaction response metadata support |
| `src/components/PageHeader.tsx` | Improve semantic heading support |
| `src/components/Sidebar.tsx` | Add active nav `aria-current` |

## Test Plan
- [x] Type-check passes: `pnpm exec tsc --noEmit`
- [ ] Lint currently has pre-existing unrelated violations in other modules
- [x] Manual walkthrough checks for target issues